### PR TITLE
Add WinWeatherBot to Trading & Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Polymarket is a decentralized information markets platform where users can trade
 
 - [polymarket-spike-bot](https://github.com/username/polymarket-spike-bot) - High-frequency spike detection bot with real-time monitoring and automated execution
 - [polymarket-trading](https://github.com/username/polymarket-trading) - Command-line trading tool with simple CLI interface
+- [WinWeatherBot](https://winweatherbot.com) - Automated weather trading for Polymarket markets; a 138-model forecast ensemble with correlation-aware sizing and sub-200ms order execution, packaged as a self-custody, Microsoft-signed Windows app
 
 ### Copy Trading
 


### PR DESCRIPTION
Adding WinWeatherBot under Trading & Execution: a self-custody, Microsoft-signed Windows app that trades Polymarket weather markets with a 138-model ensemble and sub-200ms execution. First weather-focused bot in the list, entry matches the existing format. It's a commercial tool with a public site, consistent with other non-repo entries already listed