### PR TITLE
Add PolyScore under General Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Polymarket is a decentralized information markets platform where users can trade
 - [loki.red Polymarket Stats](https://www.loki.red/polymarket/) - Comprehensive Polymarket statistics and market insights
 - [Dune Analytics - Polymarket Dashboards](https://dune.com/browse/dashboards?q=polymarket) - Multiple community-created dashboards for volume tracking, open interest, and user analytics
 - [Bitquery Polymarket API](https://bitquery.io/) - Blockchain data and on-chain analytics for Polymarket smart contracts
+- [PolyScore](https://polytrading.app) - Skill-vs-luck wallet ratings (0-100) built from full on-chain trade history; free wallet check and scored leaderboard with bots filtered out
 
 ## Trading Bots & Automation
 


### PR DESCRIPTION
Adds PolyScore (polytrading.app) — free 0–100 skill ratings for Polymarket wallets from full on-chain history, with MM-bot filtering. I'm the builder — happy to adjust the wording.