### PR TITLE
Add Live Tennis API to Data APIs & Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Polymarket is a decentralized information markets platform where users can trade
 - [Polymarket Gamma API](https://gamma-api.polymarket.com/) - Official market metadata and event data API
 - [Polymarket CLOB API](https://clob.polymarket.com/) - Official trading API with order book data and execution
 - [Bitquery Polymarket GraphQL](https://graphql.bitquery.io/) - Blockchain data and smart contract events for on-chain analytics
+- [Live Tennis API](https://livetennisapi.com) - Live tennis match-state feed (score, server, break-point flag, retirement/walkover/completed status) with player rankings and Elo for tennis event markets; free tier, no card
 
 ## Infrastructure & Integrations
 


### PR DESCRIPTION
### Add: Live Tennis API (Data APIs & Aggregators)

**Disclosure:** I run the Live Tennis API — please judge it on the merits.

This list already includes the official Polymarket Gamma API, where tennis event markets live. This PR adds a complementary **data source** for those markets: a live-tennis match-state feed. It is **not** a trading venue or execution adapter — purely a read-only data feed you'd pair with the CLOB/Gamma APIs already listed here.

What it provides on the free tier (30 req/min, 100/day, no card):
- Live scores + match state: current score object (sets/games/points), who's serving, a three-valued break-point flag, and retirement/walkover/completed status
- Players with ATP/WTA rankings and Elo
- Fixtures

Why it fits this section: enriching a tennis event-market strategy (e.g. matching a Gamma tennis market to the live match and reacting to score/serve/break-point/retirement state) needs a live match-state feed, which the currently-listed data APIs don't provide.

- API base: `https://api.livetennisapi.com/api/public/v1` (`X-API-Key` header, `{data:[...]}` envelope)
- Free key: https://livetennisapi.com/subscribe/free
- Related open-source toolkit (MIT, observe-only): https://github.com/livetennisapi/polymarket-tennis — Gamma tennis-market discovery + match↔market matching, which demonstrates the fit with the tools already on this list.

Proposed entry, appended to **Data APIs & Aggregators** (matching the existing `- [Name](url) - description` format; section is not alphabetized):

```markdown
- [Live Tennis API](https://livetennisapi.com) - Live tennis match-state feed (score, server, break-point flag, retirement/walkover/completed status) with player rankings and Elo for tennis event markets; free tier, no card
```

Happy to adjust the wording or placement to fit the list's conventions.